### PR TITLE
refactor card-stack-group with grid responsively

### DIFF
--- a/src/scss/styles/_cards.scss
+++ b/src/scss/styles/_cards.scss
@@ -754,6 +754,29 @@ was used on Traditions before switch to core blocks. Needs to be updated to work
 
 }
 
+.utkwds-card-stack-group {
+  .wp-block-columns {
+    --fr: 1fr;
+    --gap-x: 1.875rem;
+    --item-min-w: 16rem;
+    --max-cols: 3;
+    --max-gap-x-count: calc(var(--max-cols) - 1);
+    --max-total-gap-x-width: calc(var(--max-gap-x-count) * var(--gap-x));
+    --item-max-w: calc((100% - var(--max-total-gap-x-width)) / var(--max-cols));
+
+    display: grid;
+    gap: var(--gap-x);
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+
+    @media (min-width: 480px) {
+      grid-template-columns: repeat(auto-fit, minmax(max(var(--item-max-w), var(--item-min-w)), var(--fr)));
+    }
+
+    @media (min-width: 782px) {
+      --fr: .5fr;
+    }
+  }
+}
 
 .utkwds-card-stack {
   border-top: 6px solid var(--wp--preset--color--orange);


### PR DESCRIPTION
Refactor layout of Card Stack Group with a "flexible grid" approach (instead of flexbox). Fixes responsive problems. An example of the component in question can be found here: https://wds-dev.utk.edu/future-students/online-masters#infosci-masters

@nc-mhenderson Before merging, could you confirm that this doesn't affect anything it shouldn't?