### PR TITLE
Input closures

### DIFF
--- a/plugins/utk-wds-navigation-blocks/src/blocks/site-header/render.php
+++ b/plugins/utk-wds-navigation-blocks/src/blocks/site-header/render.php
@@ -95,7 +95,7 @@ if ( $custom_home_url ) {
 					<form class="form-inline hidden-print mt-4" id="cse-searchbox-form" action="<?php bloginfo( 'wpurl' ); ?>/">
 						<div class="mb-3 input-group">
 							<label class="sr-only visually-hidden" for="q">Search</label>
-							<input type="search" class="form-control" tabindex="0" title="Search this site" placeholder="Search"  name="s" id="site-search-field-slider">
+							<input type="search" class="form-control" tabindex="0" title="Search this site" placeholder="Search"  name="s" id="site-search-field-slider" />
 							<button type="submit" class="btn btn-utlink">
 								<svg width="14" height="13" viewBox="0 0 14 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 									<title>Search Icon</title>
@@ -134,7 +134,7 @@ if ( $custom_home_url ) {
 		<form class="form-inline hidden-print mt-4" id="cse-searchbox-form" action="<?php bloginfo( 'wpurl' ); ?>/">
 			<div class="mb-3 input-group">
 			<label class="sr-only visually-hidden" for="q">Search</label>
-			<input type="search" class="form-control" title="Search this site" placeholder="Search"  name="s" id="site-search-field-offcanvas">
+			<input type="search" class="form-control" title="Search this site" placeholder="Search"  name="s" id="site-search-field-offcanvas" />
 			<button type="submit" class="btn btn-utlink">
 			<svg width="14" height="13" viewBox="0 0 14 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<title>Search Icon</title>

--- a/src/search.php
+++ b/src/search.php
@@ -34,7 +34,7 @@ get_header();
     <form class="form-inline hidden-print mt-4" id="site-search-form" action="<?php bloginfo( 'wpurl' ) ?>/">
         <div class="mb-3 input-group">
         <label class="sr-only visually-hidden" for="site-search-input-tabpanel">Search</label>
-        <input type="search" class="form-control" title="Search this site" placeholder="Search"  name="s" id="site-search-input-tabpanel">
+        <input type="search" class="form-control" title="Search this site" placeholder="Search"  name="s" id="site-search-input-tabpanel" />
         <button type="submit" class="btn btn-utlink">
         <svg width="14" height="13" viewBox="0 0 14 13" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<title>Search Icon</title>


### PR DESCRIPTION
Several `<input />`  elements did not have closing slashes, which was causing interpreters to think they were still open.