### PR TITLE
restore ellipsis for email-link in contact-card (but ONLY for overflow case)

### DIFF
--- a/src/scss/styles/_cards.scss
+++ b/src/scss/styles/_cards.scss
@@ -592,20 +592,16 @@ was used on Traditions before switch to core blocks. Needs to be updated to work
   }
 
   & > .wp-block-group {
+    align-self: stretch;
     padding: 1.5rem;
     max-width: 100%;
 
     .utkwds-fancy-link {
       max-width: 100%;
-
-      a {
-        display: inline-block;
-        max-width: 100%;
-        overflow: hidden;
-        padding-left: 2px;
-        margin-left: -2px;
-        margin-bottom: -8px;
-      }
+      text-overflow: ellipsis;
+      overflow: hidden;
+      margin-left: -2px;
+      padding-left: 2px;
     }
   }
 }


### PR DESCRIPTION
In contact-card, make email-links cut off with ellipsis when needed (i.e., when the text would otherwise overflow).