### PR TITLE
mobile styling for search-inputs in tabs

### DIFF
--- a/src/scss/regions/_search.scss
+++ b/src/scss/regions/_search.scss
@@ -96,10 +96,12 @@
   }
 
   button.gsc-search-button {
-    &::after {
-      content: 'Search';
-      @supports (content: 'x' / 'y') {
-        content: 'Search' / '';
+    @media (min-width: 380px) {
+      &::after {
+        content: 'Search';
+        @supports (content: 'x' / 'y') {
+          content: 'Search' / '';
+        }
       }
     }
 
@@ -219,6 +221,14 @@
 
       > * {
         display: block;
+      }
+
+      > span {
+        display: none;
+
+        @media (min-width: 380px) {
+          display: block;
+        }
       }
 
       &:focus {


### PR DESCRIPTION
For the search forms on mobile, suppress the "SEARCH" text in the submit-button.

@wonkeythemonkey I'm doing it this way because I can make it work for the Google one as well. Does that seem reasonable to you?