### PR TITLE
Breadcrumb and first component spacing

### DIFF
--- a/src/scss/components/_hero.scss
+++ b/src/scss/components/_hero.scss
@@ -16,7 +16,6 @@
 	min-height: 600px;
 
 	.wp-block-cover {
-		margin-top: var(--wp--preset--spacing--x-small);
 		overflow: visible;
 	}
 

--- a/src/scss/regions/_universal-header.scss
+++ b/src/scss/regions/_universal-header.scss
@@ -65,16 +65,11 @@ $menu-max-width: 1500;
 	}
 
 	border-top: solid 6px var(--wp--preset--color--orange);
-	margin-bottom: 1.155rem;
 
 	&__inner {
 		@include header_max_width();
+		padding-bottom: 1.125rem;
 		background-color: white;
-		margin-bottom: 1.125rem;
-
-		@media screen and (max-width: #{$menu-breakpoint - 1}px) {
-			padding-bottom: 1rem;
-		}
 	}
 
 	&__logo {
@@ -256,7 +251,7 @@ $menu-max-width: 1500;
 			position: relative;
 
 			&:first-child {
-				margin-left: -0.875rem;
+				margin-left: -0.6rem;
 			}
 
 			ul {
@@ -384,21 +379,17 @@ $menu-max-width: 1500;
 
 .universal-header__inner-blocks {
 	@include header_max_width();
+	margin-bottom: 1.125rem;
 	background-color: white;
-	margin-top: -1.125rem;
-	padding-top: 1.125rem;
-	//padding-bottom: 0.75rem;
 
 	@media screen and (max-width: #{$menu-breakpoint - 1}px) {
 		& > :first-child {
-			margin-top: -1.125rem;
 			padding-top: 1.125rem;
 			border-top: solid 1px #d9d9d9;
 		}
 	}
 
 	@media screen and (min-width: #{$menu-breakpoint}px) {
-		//padding-bottom: 1.125rem;
 		& > :first-child {
 			border-top: none;
 		}
@@ -406,9 +397,8 @@ $menu-max-width: 1500;
 }
 
 .header-site-title {
-	font-weight: 300;
-	padding-bottom: 1rem;
 	margin-top: 0px;
+	font-weight: 300;
 
 	&:not([class~="-font-size"]) {
 		font-size: 1.5rem;
@@ -455,12 +445,12 @@ $menu-max-width: 1500;
 
 	@include header_max_width();
 
-	padding-top: 0.75rem;
-	padding-bottom: 0.75rem;
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
 
 	@media screen and (min-width: #{$menu-breakpoint}px) {
 		--utk-breadcrumb--font-size: 0.815rem;
-		padding-top: 1.125rem;
-		padding-bottom: 1.125rem;
+		margin-top: 1.125rem;
+		margin-bottom: 1.125rem;
 	}
 }

--- a/src/scss/regions/_universal-header.scss
+++ b/src/scss/regions/_universal-header.scss
@@ -450,7 +450,7 @@ $menu-max-width: 1500;
 
 	@media screen and (min-width: #{$menu-breakpoint}px) {
 		--utk-breadcrumb--font-size: 0.815rem;
-		margin-top: 1.125rem;
-		margin-bottom: 1.125rem;
+		margin-top: 1rem;
+		margin-bottom: 1rem;
 	}
 }

--- a/src/scss/regions/_universal-header.scss
+++ b/src/scss/regions/_universal-header.scss
@@ -460,5 +460,6 @@ $menu-max-width: 1500;
 	@media screen and (min-width: #{$menu-breakpoint}px) {
 		--utk-breadcrumb--font-size: 0.815rem;
 		padding-top: 1.125rem;
+		padding-bottom: 1.125rem;
 	}
 }

--- a/src/scss/regions/_universal-header.scss
+++ b/src/scss/regions/_universal-header.scss
@@ -456,6 +456,7 @@ $menu-max-width: 1500;
 	@include header_max_width();
 
 	padding-top: 0.75rem;
+	padding-bottom: 0.75rem;
 
 	@media screen and (min-width: #{$menu-breakpoint}px) {
 		--utk-breadcrumb--font-size: 0.815rem;

--- a/src/scss/styles/_fixes.scss
+++ b/src/scss/styles/_fixes.scss
@@ -80,17 +80,6 @@ Fixes aimed at certain browsers or os versions
 	gap: 60px;
 }
 
-// breadcrumbs background when first child has light background
-.page-template-no-title
-	.wp-block-post-content
-	> .has-light-background-color:first-child:not(
-		.utkwds-media-text,
-		.utkwds-media-quote
-	) {
-	padding-top: 70px !important;
-	margin-top: -38px !important;
-}
-
 .page-template-no-title .utk-breadcrumbs-wrapper {
 	position: relative;
 	z-index: 10;


### PR DESCRIPTION
For #677

This PR changes around some of the margin/padding between the logo, site title, and breadcrumb elements, which the last two may or may not be shown depending on the template.