### PR TITLE
Better A11y Elements

### DIFF
--- a/src/blocks/nav-menu/render.php
+++ b/src/blocks/nav-menu/render.php
@@ -27,7 +27,13 @@ if ( ! $menu_name ) {
 }
 
 // Use menu_name to determine menu location.
-$menu_location = 'Main Nav Menu' === $menu_name ? 'main' : 'footer';
+if ( 'Main Nav Menu' === $menu_name ) {
+	$menu_location = 'main';
+	$menu_label    = 'Primary Navigation';
+} else {
+	$menu_location = 'footer';
+	$menu_label    = 'Footer Navigation';
+}
 
 // Get menu by location to allow renaming of main nav menu.
 $locations = get_nav_menu_locations();
@@ -50,7 +56,7 @@ $anchor     = isset( $attributes['id'] ) ? $attributes['id'] : '';
 
 if ( count( $links ) ) :
 	?>
-	<div <?php echo( 'id="' . esc_attr( $anchor ) . '"' ); ?> class="wp-block-utk-wds-nav-menu utk-nav-menu-wrapper<?php echo( esc_attr( $class_name ) ); ?>">
+	<nav <?php echo( 'id="' . esc_attr( $anchor ) . '"' ); ?> class="wp-block-utk-wds-nav-menu utk-nav-menu-wrapper<?php echo( esc_attr( $class_name ) ); ?>" aria-label="<?php echo esc_attr( $menu_label ); ?>">
 		<?php
 		echo wp_kses_post(
 			$nav_menu->get_menu_markup(
@@ -63,6 +69,6 @@ if ( count( $links ) ) :
 			)
 		);
 		?>
-	</div>
+	</nav>
 	<?php
 endif;

--- a/src/blocks/nav-menu/style.scss
+++ b/src/blocks/nav-menu/style.scss
@@ -38,10 +38,6 @@ $dropdown-spacer: 0;
 	/* --utk-nav-menu--link-disabled-color: inherit; */
 }
 
-.bold-wrapper {
-	display: none;
-}
-
 .utk-nav-menu {
 	@at-root #{&}-wrapper {
 		font-size: var(--utk-nav-menu--font-size, inherit);

--- a/src/blocks/site-header/render.php
+++ b/src/blocks/site-header/render.php
@@ -45,6 +45,8 @@ function build_menu( $menu_attributes ) {
 
 	$menu            = new Menu( $menu_name );
 	$links           = $menu->get_links();
+	$wrapper_element = isset( $menu_attributes['wrapper_element'] ) ? $menu_attributes['wrapper_element'] : 'div';
+	$wrapper_label   = isset( $menu_attributes['wrapper_label'] ) ? $menu_attributes['wrapper_label'] : 'Navigation';
 	$class_name      = isset( $menu_attributes['className'] ) ? ' ' . $menu_attributes['className'] : '';
 	$item_class_name = isset( $menu_attributes['list_item_classes'] ) ? ' ' . $menu_attributes['list_item_classes'] : '';
 	$interactive     = isset( $menu_attributes['interactive'] ) ? ' ' . $menu_attributes['interactive'] : '';
@@ -52,7 +54,7 @@ function build_menu( $menu_attributes ) {
 
 	if ( count( $links ) ) :
 		?>
-		<div class="wp-block-utk-wds-nav-menu utk-nav-menu-wrapper <?php echo( esc_attr( $class_name ) ); ?>">
+		<<?php echo esc_attr( $wrapper_element ); ?> class="wp-block-utk-wds-nav-menu utk-nav-menu-wrapper <?php echo( esc_attr( $class_name ) ); ?>" aria-label="<?php echo esc_attr( $wrapper_label ); ?>">
 			<?php
 			echo wp_kses_post(
 				$menu->get_menu_markup(
@@ -68,7 +70,7 @@ function build_menu( $menu_attributes ) {
 				)
 			);
 			?>
-		</div>
+		</<?php echo esc_attr( $wrapper_element ); ?>>
 		<?php
 	endif;
 }
@@ -128,10 +130,12 @@ if ( $custom_home_url ) {
 			<?php
 			build_menu(
 				array(
-					'menuName'  => $utility_menu_name,
-					'depth'     => '0',
-					'id'        => 'utility-nav-menu--large',
-					'className' => 'utility-nav-menu--large',
+					'menuName'        => $utility_menu_name,
+					'wrapper_element' => 'nav',
+					'wrapper_label'   => 'Utility Navigation',
+					'depth'           => '0',
+					'id'              => 'utility-nav-menu--large',
+					'className'       => 'utility-nav-menu--large',
 				)
 			);
 			?>
@@ -195,10 +199,12 @@ if ( $custom_home_url ) {
 		<?php
 		build_menu(
 			array(
-				'menuName'  => $utility_menu_name,
-				'depth'     => '0',
-				'id'        => 'utility-nav-menu--mobile',
-				'className' => 'utility-nav-menu--mobile',
+				'menuName'        => $utility_menu_name,
+				'wrapper_element' => 'nav',
+				'wrapper_label'   => 'Mobile Utility Navigation',
+				'depth'           => '0',
+				'id'              => 'utility-nav-menu--mobile',
+				'className'       => 'utility-nav-menu--mobile',
 			)
 		);
 		?>
@@ -221,6 +227,8 @@ if ( $custom_home_url ) {
 		build_menu(
 			array(
 				'menuName'          => $main_menu_name,
+				'wrapper_element'   => 'nav',
+				'wrapper_label'     => 'Mobile Primary Navigation',
 				'id'                => 'mobile-nav-menu',
 				'list_item_classes' => 'collapsible-menu-item',
 				'depth'             => '1',

--- a/src/classes/Menu.php
+++ b/src/classes/Menu.php
@@ -316,7 +316,6 @@ class Menu {
 
 		if ( $current_depth <= $args['depth'] && isset( $link['submenu'] ) ) {
 			$submenu_args = array(
-				'list_element'      => 'ul',
 				'list_classes'      => '',
 				'list_item_classes' => $args['list_item_classes'],
 				'link_classes'      => $args['link_classes'],
@@ -387,7 +386,7 @@ class Menu {
 
 		$default_args = array(
 			'depth'               => 0,
-			'list_element'        => 'menu',
+			'list_element'        => 'ul',
 			'list_classes'        => '',
 			'list_item_classes'   => '',
 			'link_classes'        => '',

--- a/src/classes/Menu.php
+++ b/src/classes/Menu.php
@@ -417,6 +417,12 @@ class Menu {
 			$menu_items             .= $this->get_menu_item_markup( $link, $item_args, $current_depth );
 		}
 
-		return '<' . $args['list_element'] . ' id="' . $args['id'] . '"' . ' class="' . $args['list_classes'] . '">' . $menu_items . '</' . $args['list_element'] . '>';
+		return sprintf(
+			'<%1$s id="%2$s" class="%3$s">%4$s</%1$s>',
+			esc_attr( $args['list_element'] ),
+			esc_attr( $args['id'] ),
+			esc_attr( $args['list_classes'] ),
+			$menu_items
+		);
 	}
 }

--- a/src/scss/regions/_universal-header.scss
+++ b/src/scss/regions/_universal-header.scss
@@ -92,10 +92,9 @@ $menu-max-width: 1500;
 		width: 2rem;
 	}
 
-	menu {
+	ul {
 		li {
 			display: block;
-
 		}
 
 		> li {
@@ -151,7 +150,7 @@ $menu-max-width: 1500;
 		text-transform: uppercase;
 		font-size: 14px;
 
-		menu {
+		ul {
 			justify-content: space-between;
 		}
 


### PR DESCRIPTION
For #685 

- Changed all navigation list wrapping element to a more semantic `nav` element
- Changed all navigation list elements from `menu` to `ul` since `menu` isn't appropriate for a site navigation list
- Added aria-labels to each of our menu items, Primary, Primary (mobile), Utility, Utility (mobile), and Footer