### PR TITLE
style(anchor): remove text-decoration-thickness override on all links

### DIFF
--- a/src/frost.css
+++ b/src/frost.css
@@ -36,13 +36,6 @@ textarea:focus,
 	transition: all 0.2s ease-in-out;
 }
 
-a,
-a:focus,
-a:hover,
-a:not(.wp-element-button) {
-	text-decoration-thickness: 1px;
-}
-
 b,
 strong {
 	font-weight: var(--wp--custom--font-weight--medium);

--- a/src/scss/styles/_cards.scss
+++ b/src/scss/styles/_cards.scss
@@ -813,7 +813,6 @@ was used on Traditions before switch to core blocks. Needs to be updated to work
 		&:hover,
 		&:focus {
 			text-decoration: underline;
-			text-decoration-thickness: 1px;
 		}
 	}
 }


### PR DESCRIPTION
For #741 